### PR TITLE
Stop Travis build from timing out

### DIFF
--- a/build_website.R
+++ b/build_website.R
@@ -1,7 +1,7 @@
 library(portalcasting)
 
 #Update data and models
-setup_production(quiet = TRUE, verbose = FALSE)
+setup_production()
 
 #Update Website
 rmarkdown::render_site()


### PR DESCRIPTION
In some circumstances the build doesn't produce any output for 10+
minutes due to the quieting `setup_production`.
This ensures that the build keeps going.